### PR TITLE
 fix vkcube --wsi xlib and wine vkcube.exe

### DIFF
--- a/wsi/x11/surface_properties.cpp
+++ b/wsi/x11/surface_properties.cpp
@@ -291,7 +291,7 @@ PFN_vkVoidFunction surface_properties::get_proc_addr(const char *name)
 
 bool surface_properties::is_surface_extension_enabled(const layer::instance_private_data &instance_data)
 {
-   return instance_data.is_instance_extension_enabled(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+   return instance_data.is_instance_extension_enabled(VK_KHR_XCB_SURFACE_EXTENSION_NAME) || instance_data.is_instance_extension_enabled(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
 }
 
 } /* namespace x11 */


### PR DESCRIPTION
 # hash collision in fur mark

i did this to test fur mark but i get hash collision and only one frame then hamgs

~~~
apt install hangover
wine furmark.exe --demo furmark-vk --width 400 --height 400 --print-render-speed
(/data/data/com.termux/files/home/wsi-twaik/layer/private_data.cpp:123): Hash collision when adding new instance (0xb40000735c6d4d80)
frame 1 ; FPS: 0 ; dt: 0.336 ms ; t
ime: 0.0 sec
~~~

 lib hardware mali important update doesn't work otherwise
---

i also want to circulate mali fix for everyone here

https://github.com/john-peterson/platform_hardware_libhardware/commits/mali

https://github.com/john-peterson/sysvk/commits/mali

• create swap chain spam on every frame

i don't know if this is intended libgallium-24.3.4.so call libvulkan create swap chain every frame that vurn CPU cycles but maybe it is unavoidable
